### PR TITLE
lazyConnect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,12 @@ function createPool(
           reject(e);
         };
 
+        // When lazyConnect is enabled, ioredis will not emit ready events until after the ioredis gets a command
+        if (redisOptions?.lazyConnect) {
+          context.logger.info( 'Lazy connection enabled, skipping ready check.');
+          resolve(ioredis);
+        }
+
         ioredis
           .once('error', onError)
           .once('ready', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,25 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
 
 import { RedisPool } from '../src/index';
 
-
-describe('测试 ioredis-conn-pool', () => {
+describe.each([
+  {
+    lazyConnect: false,
+    name: 'lazyConnect: false',
+  },
+  {
+    lazyConnect: true,
+    name: 'lazyConnect: true',
+  },
+])('测试 ioredis-conn-pool $name', ({ lazyConnect }) => {
   let pool;
   let client;
 
@@ -18,13 +34,14 @@ describe('测试 ioredis-conn-pool', () => {
         port: 6379, // Redis port
         name: 'test',
         password: 'B213547b69b13224',
-        keyPrefix: 'test_'
+        keyPrefix: 'test_',
+        lazyConnect,
       },
       pool: {
         // 默认最小连接数为2，最大连接数为10，根据实际需要设置
         min: 2,
-        max: 10
-      }
+        max: 10,
+      },
     });
   });
 
@@ -44,7 +61,9 @@ describe('测试 ioredis-conn-pool', () => {
 
   it('测试异常情况', async () => {
     await pool.disconnect(client);
-    await expect(pool.release(client)).rejects.toThrow('Resource not currently part of this pool');
+    await expect(pool.release(client)).rejects.toThrow(
+      'Resource not currently part of this pool'
+    );
     client = null;
   });
 


### PR DESCRIPTION
When ioredis is configured for lazy connections, it will not attempt to talk to the redis server until it gets a command.  This causes a problem with the create factory method because it wants to not resolve with an ioredis until ioredis emits that it is ready...which will never happen.

The fix I'm suggesting is to just resolve with ioredis when lazy connections are enabled because otherwise callers are waiting for an event that will never happen.  I played around a bit to see if there was a useful status on ioredis or an event we could wait for but I did not find anything useful.  I believe this is the best thing we can do but I'm open to suggestions.